### PR TITLE
digest: remove deprecated interfaces

### DIFF
--- a/digest.go
+++ b/digest.go
@@ -8,11 +8,6 @@ import (
 	"strings"
 )
 
-const (
-	// DigestSha256EmptyTar is the canonical sha256 digest of empty data
-	DigestSha256EmptyTar = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-)
-
 // Digest allows simple protection of hex formatted digest strings, prefixed
 // by their algorithm. Strings of type Digest have some guarantee of being in
 // the correct format and it provides quick access to the components of a
@@ -66,11 +61,6 @@ var (
 func Parse(s string) (Digest, error) {
 	d := Digest(s)
 	return d, d.Validate()
-}
-
-// ParseDigest is deprecated. Use Parse.
-func ParseDigest(s string) (Digest, error) {
-	return Parse(s)
 }
 
 // FromReader returns the most valid digest for the underlying content using

--- a/verifiers.go
+++ b/verifiers.go
@@ -17,11 +17,6 @@ type Verifier interface {
 	Verified() bool
 }
 
-// NewDigestVerifier is deprecated. Please use Digest.Verifier.
-func NewDigestVerifier(d Digest) (Verifier, error) {
-	return d.Verifier(), nil
-}
-
 type hashVerifier struct {
 	digest Digest
 	hash   hash.Hash


### PR DESCRIPTION
These exported items are no longer supported as of the splitting out of
this package. They will be maintained elsewhere for packages that are
currently using this as `distribution/digest`.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

cc @dmcgowan @aaronlehmann 