### PR TITLE
README: Update deprecation count

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ out when using this package.
 
 The Go API, at this stage, is considered stable, unless otherwise noted.
 
-Right now, only two methods are marked as "deprecated", which may be 
+Right now, only one method is marked as "deprecated", which may be 
 removed before wider deployment.
 
 As always, before using a package export, read the [godoc](https://godoc.org/github.com/docker/go-digest).


### PR DESCRIPTION
Two deprecated methods were removed in #2, but there's still `Algorithm.New()`.