### PR TITLE
algorithm: Remove deprecated Algorithm.New()

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,6 @@ out when using this package.
 
 The Go API, at this stage, is considered stable, unless otherwise noted.
 
-Right now, only two methods are marked as "deprecated", which may be 
-removed before wider deployment.
-
 As always, before using a package export, read the [godoc](https://godoc.org/github.com/docker/go-digest).
 
 # Contributing

--- a/algorithm.go
+++ b/algorithm.go
@@ -89,11 +89,6 @@ func (a Algorithm) Digester() Digester {
 	}
 }
 
-// New is deprecated. Use Algorithm.Digester.
-func (a Algorithm) New() Digester {
-	return a.Digester()
-}
-
 // Hash returns a new hash as used by the algorithm. If not available, the
 // method will panic. Check Algorithm.Available() before calling.
 func (a Algorithm) Hash() hash.Hash {


### PR DESCRIPTION
Two deprecated methods were removed in #2.  This commit removes the last hits for a `deprecated` grep.

An alternative to #4.