### PR TITLE
MAINTAINERS: Replace spaces with tabs

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -11,9 +11,9 @@
 [Org]
 	[Org."Core maintainers"]
 		people = [
-      "aaronlehmann",
+			"aaronlehmann",
 			"dmcgowan",
-      "stevvooe"
+			"stevvooe"
 		]
 
 [people]
@@ -27,12 +27,12 @@
 	Name = "Aaron Lehmann"
 	Email = "aaron.lehmann@docker.com"
 	GitHub = "aaronlehmann"
-	
-  [people.dmcgowan]
+
+	[people.dmcgowan]
 	Name = "Derek McGowan"
 	Email = "derek@mcgstyle.net"
 	GitHub = "dmcgowan"
-  
+
 	[people.stevvooe]
 	Name = "Stephen J. Day"
 	Email = "stephen.day@docker.com"


### PR DESCRIPTION
The [upstream example][1] only uses tabs.

[1]: https://github.com/docker/opensource/blob/4f64fe220fb497c82318ccacab0b9d2176b2ce84/project-template/MAINTAINERS